### PR TITLE
add gcc to be installed else the c code cannot be compiled

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ SCL Ruby with SystemTap patches are required.
 
 ## Installation
 
-    yum -y install systemtap systemtap-runtime kernel-devel-`uname -r`
+    yum -y install gcc systemtap systemtap-runtime kernel-devel-`uname -r`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ SCL Ruby with SystemTap patches are required.
 
     yum -y install gcc systemtap systemtap-runtime kernel-devel-`uname -r`
 
-## Usage
+    Create foreman-tracer script with: 
+    curl -k https://raw.githubusercontent.com/lzap/foreman-tracer/master/foreman-tracer -o /usr/local/bin/foreman-tracer
 
+## Usage
+    
     foreman-tracer [rails|proxy|PID] [trace|calls|objects|arrays] [app|all] [25]
 
 Options:


### PR DESCRIPTION
Need gcc to be installed to compile the c code.

Else you would hit:
[root@~]# bash foreman-tracer proxy
~~~
Tracing started at Thu Nov 30 13:46:15 CET 2017
Pass 1: parsed user script and 476 library scripts using 127088virt/43456res/3160shr/40596data kb, in 470usr/90sys/2085real ms.
Pass 2: analyzed script: 14 probes, 5 functions, 1 embed, 0 globals using 137432virt/49000res/4096shr/50940data kb, in 40usr/10sys/94real ms.
Pass 3: translated to C into "/tmp/stapfzPV4F/stap_9b9a3be485804ca5928a8eded59deabd_17089_src.c" using 139928virt/49792res/4500shr/53436data kb, in 70usr/210sys/3744real ms.
arch/x86/Makefile:96: stack-protector enabled but compiler support broken
Makefile:641: Cannot use CONFIG_CC_STACKPROTECTOR_STRONG: -fstack-protector-strong not supported by compiler
make: gcc: Command not found
/bin/sh: gcc: command not found
make[1]: *** [/tmp/stapfzPV4F/stap_9b9a3be485804ca5928a8eded59deabd_17089_src.o] Error 127
make[1]: *** Waiting for unfinished jobs....
/bin/sh: gcc: command not found
make[1]: *** [/tmp/stapfzPV4F/stap_9b9a3be485804ca5928a8eded59deabd_17089_aux_0.o] Error 127
make: *** [_module_/tmp/stapfzPV4F] Error 2
WARNING: kbuild exited with status: 2
Pass 4: compiled C into "stap_9b9a3be485804ca5928a8eded59deabd_17089.ko" in 190usr/150sys/591real ms.
Pass 4: compilation failed.  [man error::pass4]
Tracing ended at Thu Nov 30 13:46:22 CET 2017
~~~